### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/src/boost_1_57_0/boost/graph/bron_kerbosch_all_cliques.hpp
+++ b/src/boost_1_57_0/boost/graph/bron_kerbosch_all_cliques.hpp
@@ -84,7 +84,7 @@ namespace boost
 //          number = {1},
 //          year = {2006},
 //          pages = {28-42}
-//          ee = {http://dx.doi.org/10.1016/j.tcs.2006.06.015}
+//          ee = {https://doi.org/10.1016/j.tcs.2006.06.015}
 //      }
 
 /**

--- a/src/boost_1_57_0/boost/graph/detail/geodesic.hpp
+++ b/src/boost_1_57_0/boost/graph/detail/geodesic.hpp
@@ -33,7 +33,7 @@ namespace boost
 //         pages = {466--484},
 //         priority = {0},
 //         title = {A Graph-theoretic perspective on centrality},
-//         url = {http://dx.doi.org/10.1016/j.socnet.2005.11.005},
+//         url = {https://doi.org/10.1016/j.socnet.2005.11.005},
 //             volume = {28},
 //             year = {2006}
 //         }

--- a/src/boost_1_57_0/libs/math/example/bessel_zeros_example.cpp
+++ b/src/boost_1_57_0/libs/math/example/bessel_zeros_example.cpp
@@ -231,7 +231,7 @@ We set the precision of the output stream and show trailing zeros to display a f
 
 /*`Finally we show how the output iterator can be used to compute a sum of zeros.
 
-(See [@http://dx.doi.org/10.1017/S2040618500034067 Ian N. Sneddon, Infinite Sums of Bessel Zeros],
+(See [@https://doi.org/10.1017/S2040618500034067 Ian N. Sneddon, Infinite Sums of Bessel Zeros],
 page 150 equation 40).
 */
 //] [/bessel_zero_example_2]

--- a/src/eigen-3.2.2/unsupported/Eigen/src/IterativeSolvers/DGMRES.h
+++ b/src/eigen-3.2.2/unsupported/Eigen/src/IterativeSolvers/DGMRES.h
@@ -88,7 +88,7 @@ void sortWithPermutation (VectorType& vec, IndexType& perm, typename IndexType::
  * [1] D. NUENTSA WAKAM and F. PACULL, Memory Efficient Hybrid
  *  Algebraic Solvers for Linear Systems Arising from Compressible
  *  Flows, Computers and Fluids, In Press,
- *  http://dx.doi.org/10.1016/j.compfluid.2012.03.023   
+ *  https://doi.org/10.1016/j.compfluid.2012.03.023   
  * [2] K. Burrage and J. Erhel, On the performance of various 
  * adaptive preconditioned GMRES strategies, 5(1998), 101-121.
  * [3] J. Erhel, K. Burrage and B. Pohl, Restarted GMRES 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates all static DOI links.

Cheers!